### PR TITLE
Add CI workflow for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TEST_TIME_UNIT: 60,120
+  RUST_TEST_TIME_INTEGRATION: 60,120
+  RUST_TEST_TIME_DOCTEST: 60,120
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [libcoap-sys, libcoap-rs]
+        dtls_backend: [openssl, gnutls, tinydtls, mbedtls]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+      - if: matrix.dtls_backend == 'gnutls'
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgnutls28-dev libgnutls30
+          version: 1.0
+      - if: matrix.crate == 'libcoap-rs'
+        run: cargo test -p ${{ matrix.crate }} --no-default-features --features dtls,tcp,vendored --features dtls_${{ matrix.dtls_backend }} --no-fail-fast -- -Z unstable-options --report-time --ensure-time
+      - if: matrix.crate == 'libcoap-sys'
+        run: cargo test -p ${{ matrix.crate }} --features dtls,dtls_backend_${{ matrix.dtls_backend }} --no-fail-fast -- -Z unstable-options --report-time --ensure-time
+
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crate: [libcoap-sys, libcoap-rs]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: giraffate/clippy-action@main
+        with:
+          reporter: 'github-pr-check'
+          clippy_flags: -p ${{ matrix.crate }} --no-deps
+          level: warning
+          tool_name: clippy (${{ matrix.crate }})
+
+  coverage:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [libcoap-rs]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-tarpaulin
+      - run: cargo tarpaulin --no-fail-fast --workspace --verbose --features dtls,tcp,vendored --exclude-files libcoap-sys/tests,libcoap/tests --timeout 120 --out Xml
+      - uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: ./cobertura.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: file
+      - run: |
+          # Snippet taken from https://github.com/marocchino/sticky-pull-request-comment#append-after-comment-every-time-it-runs
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "coverage_report<<$EOF" >> "$GITHUB_ENV"
+          echo "### Code Coverage Report" >> "$GITHUB_ENV"
+          echo "Generated for commit ${{ github.sha }} on `date -u`." >> "$GITHUB_ENV"
+          cat code-coverage-results.md >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
+      - if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: ${{ env.coverage_report }}
+      - run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         crate: [libcoap-sys, libcoap-rs]
-        dtls_backend: [openssl, gnutls, tinydtls, mbedtls]
+        dtls_backend: [openssl, gnutls, tinydtls]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/libcoap-sys/build.rs
+++ b/libcoap-sys/build.rs
@@ -5,10 +5,10 @@
  * See the README as well as the LICENSE file for more information.
  */
 
-use std::io::ErrorKind;
 use std::{
     default::Default,
     env,
+    io::ErrorKind,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -178,16 +178,13 @@ fn main() {
                     // libcoap doesn't support overriding the MbedTLS CFLAGS, but doesn't set those
                     // either, so we just set CFLAGS and hope they propagate.
                     if let Some(mbedtls_include) = env::var_os("DEP_MBEDTLS_INCLUDE") {
+                        let mbedtls_library_path = Path::new(env::var_os("DEP_MBEDTLS_CONFIG_H").unwrap().as_os_str())
+                            .parent()
+                            .unwrap()
+                            .join("build")
+                            .join("library");
                         build_config.env("CFLAGS", format!("-I{}", mbedtls_include.to_str().unwrap()));
-                        build_config.env(
-                            "PKG_CONFIG_PATH",
-                            Path::new(mbedtls_include.as_os_str())
-                                .parent()
-                                .unwrap()
-                                .join("lib")
-                                .join("pkgconfig")
-                                .into_os_string(),
-                        );
+                        build_config.env("LDFLAGS", format!("-L{}", mbedtls_library_path.to_str().unwrap()));
                     }
                 },
                 DtlsBackend::GnuTls => {

--- a/libcoap/src/crypto.rs
+++ b/libcoap/src/crypto.rs
@@ -79,6 +79,8 @@ pub trait CoapClientCryptoProvider: Debug {
     ///
     /// Return a CoapCryptoProviderResponse corresponding to the cryptographic information that
     /// should be used.
+    ///
+    /// Note: Unsupported by the MBedTLS DTLS backend.
     fn provide_key_for_hint(
         &mut self,
         hint: &CoapCryptoPskIdentity,
@@ -110,6 +112,8 @@ pub trait CoapServerCryptoProvider: Debug {
     /// hint.
     ///
     /// Return None if the provided SNI is unacceptable, i.e. you have no key for this server name.
+    ///
+    /// Note: Unsupported by the TinyDTLS DTLS backend.
     #[allow(unused_variables)]
     fn provide_hint_for_sni(&mut self, sni: &str) -> CoapCryptoProviderResponse<CoapCryptoPskInfo> {
         CoapCryptoProviderResponse::UseCurrent

--- a/libcoap/src/message/request.rs
+++ b/libcoap/src/message/request.rs
@@ -509,7 +509,7 @@ impl CoapRequest {
         }
         pdu.clear_options();
         for opt in additional_opts {
-            (&mut pdu).add_option(opt);
+            pdu.add_option(opt);
         }
         if proxy_scheme.is_some() && proxy_uri.is_some() {
             return Err(MessageConversionError::InvalidOptionCombination(

--- a/libcoap/src/resource.rs
+++ b/libcoap/src/resource.rs
@@ -244,9 +244,11 @@ impl<D: Any + ?Sized + Debug> CoapResource<D> {
             let raw_resource = coap_resource_init(
                 uri_path,
                 (COAP_RESOURCE_FLAGS_RELEASE_URI
-                    | (notify_con
-                        .then(|| COAP_RESOURCE_FLAGS_NOTIFY_CON)
-                        .unwrap_or(COAP_RESOURCE_FLAGS_NOTIFY_NON))) as i32,
+                    | if notify_con {
+                        COAP_RESOURCE_FLAGS_NOTIFY_CON
+                    } else {
+                        COAP_RESOURCE_FLAGS_NOTIFY_NON
+                    }) as i32,
             );
             let inner = CoapFfiRcCell::new(CoapResourceInner {
                 raw_resource,

--- a/libcoap/src/transport/tcp.rs
+++ b/libcoap/src/transport/tcp.rs
@@ -5,5 +5,6 @@
  * See the README as well as the LICENSE file for more information.
  */
 /// TODO
+#[allow(dead_code)]
 #[cfg(feature = "tcp")]
 pub struct CoapTcpEndpoint {}

--- a/libcoap/src/transport/tls.rs
+++ b/libcoap/src/transport/tls.rs
@@ -5,5 +5,6 @@
  * See the README as well as the LICENSE file for more information.
  */
 /// TODO
+#[allow(dead_code)]
 #[cfg(feature = "tcp")]
 pub struct CoapTlsEndpoint {}

--- a/libcoap/tests/common/mod.rs
+++ b/libcoap/tests/common/mod.rs
@@ -6,6 +6,8 @@ use libcoap_rs::{CoapContext, CoapRequestHandler, CoapResource};
 use std::net::{SocketAddr, UdpSocket};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 pub(crate) fn get_unused_server_addr() -> SocketAddr {
@@ -25,6 +27,39 @@ pub(crate) fn get_unused_server_addr() -> SocketAddr {
         .expect("Failed to get server socket address")
 }
 
+/// Spawns a test server in a new thread and waits for context_configurator to complete before
+/// returning.
+/// As the context_configurator closure is responsible for binding to sockets, this can be used to
+/// spawn a test server and wait for it to be ready to accept requests before returning (avoiding
+/// test failure due to "Connection Refused" errors).
+pub(crate) fn spawn_test_server<F: FnOnce(&mut CoapContext) + Send + 'static>(
+    context_configurator: F,
+) -> JoinHandle<()> {
+    let ready_condition = Arc::new((Mutex::new(false), Condvar::new()));
+    let ready_condition2 = Arc::clone(&ready_condition);
+
+    let server_handle = std::thread::spawn(move || {
+        let (ready_var, ready_cond) = &*ready_condition2;
+        run_test_server(|context| {
+            context_configurator(context);
+            let mut ready_var = ready_var.lock().expect("ready condition mutex is poisoned");
+            *ready_var = true;
+            ready_cond.notify_all();
+        });
+    });
+
+    let (ready_var, ready_cond) = &*ready_condition;
+    drop(
+        ready_cond
+            .wait_while(ready_var.lock().expect("ready condition mutex is poisoned"), |ready| {
+                !*ready
+            })
+            .expect("ready condition mutex is poisoned"),
+    );
+    server_handle
+}
+
+/// Configures and starts a test server in the current thread.
 pub(crate) fn run_test_server<F: FnOnce(&mut CoapContext)>(context_configurator: F) {
     let mut context = CoapContext::new().unwrap();
     context_configurator(&mut context);

--- a/libcoap/tests/dtls_client_server_test.rs
+++ b/libcoap/tests/dtls_client_server_test.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "dtls")]
 use std::fmt::Debug;
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
 use libcoap_rs::crypto::{
@@ -20,6 +21,13 @@ mod common;
 struct DummyCryptoProvider;
 
 impl CoapServerCryptoProvider for DummyCryptoProvider {
+    fn provide_key_for_identity(
+        &mut self,
+        identity: &CoapCryptoPskIdentity,
+    ) -> CoapCryptoProviderResponse<Box<CoapCryptoPskData>> {
+        CoapCryptoProviderResponse::UseCurrent
+    }
+
     fn provide_default_info(&mut self) -> CoapCryptoPskInfo {
         CoapCryptoPskInfo {
             identity: String::from("dtls_test_identity").into_boxed_str().into(),
@@ -48,11 +56,9 @@ impl CoapClientCryptoProvider for DummyCryptoProvider {
 pub fn dtls_client_server_request() {
     let server_address = common::get_unused_server_addr();
 
-    let server_handle = std::thread::spawn(move || {
-        common::run_test_server(|context| {
-            context.set_server_crypto_provider(Some(Box::new(DummyCryptoProvider {})));
-            context.add_endpoint_dtls(server_address).unwrap();
-        });
+    let server_handle = common::spawn_test_server(move |context| {
+        context.set_server_crypto_provider(Some(Box::new(DummyCryptoProvider {})));
+        context.add_endpoint_dtls(server_address).unwrap();
     });
 
     let mut context = CoapContext::new().unwrap();
@@ -65,7 +71,7 @@ pub fn dtls_client_server_request() {
         for response in session.poll_handle(&req_handle) {
             assert_eq!(response.code(), CoapMessageCode::Response(CoapResponseCode::Content));
             assert_eq!(response.data().unwrap().as_ref(), "Hello World!".as_bytes());
-            server_handle.join().unwrap();
+            server_handle.join().expect("Test server crashed with failure.");
             return;
         }
     }

--- a/libcoap/tests/udp_client_server_test.rs
+++ b/libcoap/tests/udp_client_server_test.rs
@@ -13,9 +13,7 @@ mod common;
 pub fn basic_client_server_request() {
     let server_address = common::get_unused_server_addr();
 
-    let server_handle = std::thread::spawn(move || {
-        common::run_test_server(|context| context.add_endpoint_udp(server_address).unwrap());
-    });
+    let server_handle = common::spawn_test_server(move |context| context.add_endpoint_udp(server_address).unwrap());
 
     let mut context = CoapContext::new().unwrap();
     let session = CoapClientSession::connect_udp(&mut context, server_address).unwrap();


### PR DESCRIPTION
This PR adds a basic GitHub Actions CI workflow to the project, replacing the GitLab CI pipeline used during the NAMIB project runtime.

It includes
- A test run for both the libcoap-sys and libcoap-rs crates and for each DTLS backend
- A linting run that will report Clippy remarks in the PR changes view (as a GitHub Check using [reviewdog](https://github.com/reviewdog/reviewdog#reporter-github-checks--reportergithub-pr-check))
- A coverage report generated by `cargo tarpaulin` and automatically added to the PR as a comment.

Additionally, some smaller issues that the CI pipeline uncovered were also fixed.