### PR TITLE
Bump version to 0.2.2 and update copyright notices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,9 @@
-# SPDX-License-Identifier: EPL-1.0 OR BSD-3-CLAUSE
+# SPDX-License-Identifier: BSD-2-Clause
+# Cargo.toml for the libcoap-rs repository.
+# This file is part of the libcoap-rs library, see the README and LICENSE files for
+# more information and terms of use.
+# Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
+# See the README as well as the LICENSE file for more information.
 [workspace]
 members = [
     "libcoap",

--- a/LICENSE-BSD-2-CLAUSE
+++ b/LICENSE-BSD-2-CLAUSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2021 The NAMIB Project Developers
+Copyright © 2021-2023 The NAMIB Project Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/libcoap-sys/Cargo.toml
+++ b/libcoap-sys/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 name = "libcoap-sys"
 description = "Raw bindings to the libcoap CoAP library."
-version = "0.2.1+libcoap-4.3.1"
+version = "0.2.2+libcoap-4.3.1"
 edition = "2021"
 license = "BSD-2-Clause AND BSD-1-Clause"
 links = "coap-3"

--- a/libcoap-sys/Cargo.toml
+++ b/libcoap-sys/Cargo.toml
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Cargo.toml for libcoap-sys
-# Copyright (c) 2021-2022 The NAMIB Project Developers, all rights reserved.
-# See the README as well as the LICENSE file for more information.
+# This file is part of the libcoap-sys crate, see the README and LICENSE files for
+# more information and terms of use.
+# Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
 
 [package]
 name = "libcoap-sys"

--- a/libcoap-sys/build.rs
+++ b/libcoap-sys/build.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BSD-2-CLAUSE
 /*
  * build.rs - build script for libcoap Rust bindings.
- * Copyright (c) 2021 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-sys crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
 

--- a/libcoap-sys/src/lib.rs
+++ b/libcoap-sys/src/lib.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * lib.rs - Main library entry point for raw libcoap bindings.
- * Copyright (c) 2021-2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-sys crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Auto-generated unsafe bindings to [libcoap](https://github.com/obgm/libcoap), generated using
 //! [bindgen](https://crates.io/crates/bindgen).
 //!

--- a/libcoap-sys/src/wrapper.h
+++ b/libcoap-sys/src/wrapper.h
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * wrapper.h - wrapper header to generate libcoap Rust bindings using bindgen
- * Copyright (c) 2021 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-sys crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 #include <coap3/coap.h>

--- a/libcoap/Cargo.toml
+++ b/libcoap/Cargo.toml
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Cargo.toml for libcoap
-# Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
-# See the README as well as the LICENSE file for more information.
+# This file is part of the libcoap-rs crate, see the README and LICENSE files for
+# more information and terms of use.
+# Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
 
 [package]
 name = "libcoap-rs"

--- a/libcoap/Cargo.toml
+++ b/libcoap/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 name = "libcoap-rs"
 description = "An idiomatic wrapper around the libcoap CoAP library for Rust."
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "BSD-2-Clause"
 readme = "README.md"
@@ -28,7 +28,7 @@ nightly = []
 vendored = ["libcoap-sys/vendored"]
 
 [dependencies]
-libcoap-sys = { version = "^0.2.1", path = "../libcoap-sys" }
+libcoap-sys = { version = "^0.2.2", path = "../libcoap-sys" }
 libc = { version = "^0.2.95" }
 num-derive = { version = "^0.3.3" }
 num-traits = { version = "^0.2.14" }

--- a/libcoap/src/context.rs
+++ b/libcoap/src/context.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * context.rs - CoAP context related code.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Module containing context-internal types and traits.
 
 use std::{any::Any, ffi::c_void, fmt::Debug, marker::PhantomData, net::SocketAddr, ops::Sub, time::Duration};

--- a/libcoap/src/crypto.rs
+++ b/libcoap/src/crypto.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * crypto.rs - CoAP cryptography provider interfaces and types.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Cryptography provider interfaces and types
 
 use std::{

--- a/libcoap/src/error.rs
+++ b/libcoap/src/error.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * error.rs - CoAP error types.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Error types
+
 use std::string::FromUtf8Error;
 
 use thiserror::Error;

--- a/libcoap/src/event.rs
+++ b/libcoap/src/event.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * event.rs - Event handling traits and logic for the libcoap Rust Wrapper.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Event handling-related code
+
 use std::fmt::Debug;
 
 use libcoap_sys::{coap_event_t, coap_session_get_context, coap_session_t};

--- a/libcoap/src/lib.rs
+++ b/libcoap/src/lib.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * lib.rs - Main library entry point for safe libcoap bindings.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 #![cfg_attr(feature = "nightly", feature(trait_upcasting))]
 
 //! A safe wrapper around the libcoap C library.

--- a/libcoap/src/mem.rs
+++ b/libcoap/src/mem.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * mem.rs - Memory handling helper structs and traits for the libcoap Rust Wrapper.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Code related to memory handling, especially for passing objects through FFI
 
 use std::cell::{Ref, RefCell, RefMut};

--- a/libcoap/src/message/mod.rs
+++ b/libcoap/src/message/mod.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * message.rs - Types related to CoAP messages.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Types related to message handling, parsing and creation.
 //!
 //! The base unit that is transmitted between a CoAP client and a CoAP server is called a CoAP

--- a/libcoap/src/message/request.rs
+++ b/libcoap/src/message/request.rs
@@ -1,10 +1,13 @@
-use std::fmt::{Display, Formatter};
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * request.rs - Types wrapping messages into requests and responses.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * request.rs - Types wrapping messages into requests.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use url::Url;

--- a/libcoap/src/message/response.rs
+++ b/libcoap/src/message/response.rs
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * response.rs - Types wrapping messages into responses.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
+ * See the README as well as the LICENSE file for more information.
+ */
+
 use crate::error::{MessageConversionError, MessageTypeError, OptionValueError};
 use crate::message::{CoapMessage, CoapMessageCommon, CoapOption};
 use crate::protocol::{

--- a/libcoap/src/protocol.rs
+++ b/libcoap/src/protocol.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * protocol.rs - Types representing CoAP protocol values.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Various types that are specified and defined in the CoAP standard and its extensions.
 
 use std::{

--- a/libcoap/src/resource.rs
+++ b/libcoap/src/resource.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * resource.rs - Types relating to CoAP resource management.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Resource and resource handler descriptions
 
 use std::{

--- a/libcoap/src/session/client.rs
+++ b/libcoap/src/session/client.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * session/client.rs - Types relating to client-side CoAP sessions.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
 

--- a/libcoap/src/session/mod.rs
+++ b/libcoap/src/session/mod.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * session/mod.rs - Types relating to generic CoAP sessions.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
 

--- a/libcoap/src/session/server.rs
+++ b/libcoap/src/session/server.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * session/server.rs - Types relating to client-side CoAP sessions.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
 

--- a/libcoap/src/transport/dtls.rs
+++ b/libcoap/src/transport/dtls.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * transport/dtls.rs - transport-specific code for DTLS.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 use std::net::SocketAddr;
 
 use libcoap_sys::{coap_endpoint_t, coap_free_endpoint, coap_new_endpoint, coap_proto_t::COAP_PROTO_DTLS};
 
-use crate::{
-    context::CoapContext, error::EndpointCreationError, transport::EndpointCommon,
-    types::CoapAddress,
-};
+use crate::{context::CoapContext, error::EndpointCreationError, transport::EndpointCommon, types::CoapAddress};
 
 #[derive(Debug)]
 pub struct CoapDtlsEndpoint {

--- a/libcoap/src/transport/mod.rs
+++ b/libcoap/src/transport/mod.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * transport/mod.rs - Module file for CoAP transports.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 use std::os::raw::c_uint;
 
 use libcoap_sys::{coap_endpoint_set_default_mtu, coap_endpoint_t};

--- a/libcoap/src/transport/tcp.rs
+++ b/libcoap/src/transport/tcp.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * transport/dtls.rs - transport-specific code for TCP.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 /// TODO
 #[allow(dead_code)]
 #[cfg(feature = "tcp")]

--- a/libcoap/src/transport/tls.rs
+++ b/libcoap/src/transport/tls.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * transport/dtls.rs - transport-specific code for TLS.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 /// TODO
 #[allow(dead_code)]
 #[cfg(feature = "tcp")]

--- a/libcoap/src/transport/udp.rs
+++ b/libcoap/src/transport/udp.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * transport/dtls.rs - transport-specific code for UDP.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 use std::net::SocketAddr;
 
 use libcoap_sys::{coap_endpoint_t, coap_free_endpoint, coap_new_endpoint, coap_proto_t::COAP_PROTO_UDP};
-
 
 use crate::{context::CoapContext, error::EndpointCreationError, transport::EndpointCommon, types::CoapAddress};
 

--- a/libcoap/src/types.rs
+++ b/libcoap/src/types.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * resource.rs - Types for converting between libcoap and Rust data structures.
- * Copyright (c) 2022 The NAMIB Project Developers, all rights reserved.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
  * See the README as well as the LICENSE file for more information.
  */
+
 //! Types required for conversion between libcoap C library abstractions and Rust types.
 
 use std::fmt::{Display, Formatter};

--- a/libcoap/tests/common/mod.rs
+++ b/libcoap/tests/common/mod.rs
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * tests/common/mod.rs - Common code for integration tests.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
+ * See the README as well as the LICENSE file for more information.
+ */
+
 use libcoap_rs::message::{CoapMessageCommon, CoapRequest, CoapResponse};
 use libcoap_rs::protocol::{CoapMessageCode, CoapMessageType, CoapRequestCode, CoapResponseCode};
 use libcoap_rs::session::CoapSessionCommon;

--- a/libcoap/tests/dtls_client_server_test.rs
+++ b/libcoap/tests/dtls_client_server_test.rs
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * dtls_client_server_test.rs - Tests for DTLS clients+servers.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
+ * See the README as well as the LICENSE file for more information.
+ */
+
 #![cfg(feature = "dtls")]
 use std::fmt::Debug;
 use std::sync::{Arc, Condvar, Mutex};

--- a/libcoap/tests/udp_client_server_test.rs
+++ b/libcoap/tests/udp_client_server_test.rs
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * dtls_client_server_test.rs - Tests for UDP clients+servers.
+ * This file is part of the libcoap-rs crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
+ * See the README as well as the LICENSE file for more information.
+ */
+
 use libcoap_rs::session::CoapClientSession;
 use libcoap_rs::{
     message::CoapMessageCommon,


### PR DESCRIPTION
Bumped the version number for release, replaced all copyright notices with a unified one, added some missing copyright notices.