### PR TITLE
Add compile-time and runtime checks for feature availability

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,9 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="DO_NOT_FORMAT">
+      <list>
+        <fileSet type="globPattern" pattern="libcoap-sys/src/wrapper.h" />
+      </list>
+    </option>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/runConfigurations/Test.xml
+++ b/.idea/runConfigurations/Test.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="test -p libcoap-rs --no-default-features --features vendored,dtls,dtls_mbedtls,tcp,rand" />
+    <option name="command" value="test -p libcoap-rs " />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/libcoap-sys/Cargo.toml
+++ b/libcoap-sys/Cargo.toml
@@ -62,8 +62,9 @@ static = []
 # Corresponding libcoap configure flag: --enable-dtls
 dtls = []
 # Enable this feature to enable/require TLS support in addition to DTLS support.
-# Note: Will also enable the DTLS feature, so consider the above section regarding DTLS backends before enabling this.
-tls = ["dtls"]
+# Note: Will also enable the TCP and DTLS features, so consider the above section regarding DTLS backends before +
+# enabling this.
+tls = ["dtls", "tcp"]
 # Enable this feature to enable/require OSCORE functionality in the C library.
 # Corresponding libcoap configure flag: --enable-oscore
 oscore = []
@@ -97,6 +98,7 @@ q-block = []
 # Corresponding libcoap configure flag: --enable-thread-safe
 thread-safe = []
 # Enable this feature to enable/require recursive lock detection in the C library.
+# Will also implicitly enable the `thread-safe` feature.
 # Corresponding libcoap configure flag: --enable-thread-recursive-lock-detection
 thread-recursive-lock-detection = ["thread-safe"]
 # Enable this feature to set/require the small stack flag in the C library.
@@ -114,7 +116,7 @@ epoll = []
 # Enable this feature to require support for CoAP over WebSockets using TLS in the C library.
 # Whether this feature is supported by the C library depends on the used DTLS library.
 secure-websockets = ["tls", "websockets"]
-# Enabling this feature to require support for CIDs in DTLS in the C library.
+# Enable this feature to require support for CIDs in DTLS in the C library.
 # Whether this feature is supported by the C library depends on the used DTLS library.
 dtls-cid = ["dtls"]
 # Enabling this feature to require support for DTLS-PSK in the C library.

--- a/libcoap-sys/Cargo.toml
+++ b/libcoap-sys/Cargo.toml
@@ -2,7 +2,7 @@
 # Cargo.toml for libcoap-sys
 # This file is part of the libcoap-sys crate, see the README and LICENSE files for
 # more information and terms of use.
-# Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
+# Copyright © 2021-2024 The NAMIB Project Developers, all rights reserved.
 
 [package]
 name = "libcoap-sys"
@@ -22,7 +22,7 @@ resolver = "2"
 [features]
 # The default features match those of libcoaps configure script, except for dtls, which is disabled here because it
 # requires a backend to be set manually.
-default = ["server", "client", "tcp", "async", "epoll", "vendored", "static"]
+default = ["oscore", "ipv4", "ipv6", "af-unix", "tcp", "websockets", "async", "observe-persist", "q-block", "thread-safe", "thread-recursive-lock-detection", "server", "client", "epoll", "vendored", "static"]
 # While not specified here due to limitations in Cargo's syntax, the DTLS feature depends on one of the DTLS backends
 # being enabled.
 # If you are developing a library based on libcoap-sys and do not care about the DTLS backend, enable the dtls feature
@@ -34,12 +34,17 @@ default = ["server", "client", "tcp", "async", "epoll", "vendored", "static"]
 # exclusive features. If multiple backends are enabled (e.g. because multiple dependencies use libcoap-sys and use
 # different backends), we select one based on the auto-detection order specified in
 # https://github.com/obgm/libcoap/blob/develop/configure.ac#L494 (gnutls > openssl > mbedtls > tinydtls).
-dtls = []
+
+
+# Corresponding libcoap configure flag: --with-openssl
 dtls_backend_openssl = ["dtls", "dep:openssl-sys"]
 dtls_backend_openssl_vendored = ["dtls_backend_openssl", "openssl-sys/vendored"]
+# Corresponding libcoap configure flag: --with-gnutls
 dtls_backend_gnutls = ["dtls"]
+# Corresponding libcoap configure flag: --with-mbedtls
 dtls_backend_mbedtls = ["dtls"] # can't use mbedtls-sys-auto to generate linker flags here, as the crate doesn't support mbedtls >= 3.0.0
 dtls_backend_mbedtls_vendored = ["dep:mbedtls-sys-auto", "dtls_backend_mbedtls"]
+# Corresponding libcoap configure flags: --with-tinydtls --without-submodule-tinydtls
 dtls_backend_tinydtls = ["dtls", "dep:tinydtls-sys", "tinydtls-sys/ecc", "tinydtls-sys/psk"]
 dtls_backend_tinydtls_vendored = ["dtls_backend_tinydtls", "tinydtls-sys/vendored"]
 # Enabling this feature will force libcoap-sys to be built with and statically linked to a vendored version of libcoap,
@@ -51,18 +56,79 @@ static = []
 # --- FEATURE FLAGS ---
 # Note that setting the feature flags currently has no effect on the generated Rust code, because the libcoap headers do
 # not use these feature flags. They only affect the features built into the vendored C library (if enabled).
-# Enable this feature to support CoAP over TCP
+
+# Enable this feature to enable/require CoAP over DTLS support in the C library.
+# Important: also read the section on DTLS backends before enabling this feature.
+# Corresponding libcoap configure flag: --enable-dtls
+dtls = []
+# Enable this feature to enable/require TLS support in addition to DTLS support.
+# Note: Will also enable the DTLS feature, so consider the above section regarding DTLS backends before enabling this.
+tls = ["dtls"]
+# Enable this feature to enable/require OSCORE functionality in the C library.
+# Corresponding libcoap configure flag: --enable-oscore
+oscore = []
+# Enable this feature to enable/require IPv4 support in the C library.
+# Corresponding libcoap configure flag: --enable-ipv4-support
+ipv4 = []
+# Enable this feature to enable/require IPv6 support in the C library.
+# Corresponding libcoap configure flag: --enable-ipv6-support
+ipv6 = []
+# Enable this feature to enable/require support for Unix sockets in the C library.
+# Corresponding libcoap configure flag: --enable-af-unix-support
+af-unix = []
+# Enable this feature to enable/require support for CoAP over TCP in the C library.
+# Corresponding libcoap configure flag: --enable-tcp
 tcp = []
-# Enable this feature to enable async functionality in libcoap.
-# Note that this does not generate async-functions as they are used in Rust, just the necessary functions in the C
-# library to make asynchronous requests.
+# Enable this feature to enable/require CoAP over WebSockets in the C library.
+# Corresponding libcoap configure flag: --enable-websockets
+websockets = []
+# Enable this feature to enable/require async functionality in the C library.
+# Note that this does not generate async-functions as they are used in Rust, it allows for CoAP separate responses as
+# specified in RFC 7252, Section 5.2.2.
+# Corresponding libcoap configure flag: --enable-async
 async = []
-# Enable this feature for server functionality.
+# Enable this feature to enable/require support for persisting observes over a server restart in the C library.
+# Corresponding libcoap configure flag: --enable-observe-persist
+observe-persist = []
+# Enable this feature to enable/require Q-Block support in the C library.
+# Corresponding libcoap configure flag: --enable-q-block
+q-block = []
+# Enable this feature to enable/require the thread-safety facilities in the C library to be enabled.
+# Corresponding libcoap configure flag: --enable-thread-safe
+thread-safe = []
+# Enable this feature to enable/require recursive lock detection in the C library.
+# Corresponding libcoap configure flag: --enable-thread-recursive-lock-detection
+thread-recursive-lock-detection = ["thread-safe"]
+# Enable this feature to set/require the small stack flag in the C library.
+# Corresponding libcoap configure flag: --enable-small-stack
+small-stack = []
+# Enable this feature to enable/require server functionality in the C library.
+# Corresponding libcoap configure flag: --enable-server-mode
 server = []
-# Enable this feature for client functionality.
+# Enable this feature to enable/require client functionality in the C library.
+# Corresponding libcoap configure flag: --enable-client-mode
 client = []
-# Enable this feature to enable epoll usage in the C library.
+# Enable this feature to enable/require epoll usage in the C library.
+# Corresponding libcoap configure flag: --with-epoll
 epoll = []
+# Enable this feature to require support for CoAP over WebSockets using TLS in the C library.
+# Whether this feature is supported by the C library depends on the used DTLS library.
+secure-websockets = ["tls", "websockets"]
+# Enabling this feature to require support for CIDs in DTLS in the C library.
+# Whether this feature is supported by the C library depends on the used DTLS library.
+dtls-cid = ["dtls"]
+# Enabling this feature to require support for DTLS-PSK in the C library.
+# Whether this feature is supported by the C library depends on the used DTLS library.
+dtls-psk = ["dtls"]
+# Enabling this feature to require support for DTLS-PKI in the C library.
+# Whether this feature is supported by the C library depends on the used DTLS library.
+dtls-pki = ["dtls"]
+# Enabling this feature to require support for DTLS-PKCS11 in the C library.
+# Whether this feature is supported by the C library depends on the used DTLS library.
+dtls-pkcs11 = ["dtls"]
+# Enabling this feature to require support for DTLS-RPK in the C library.
+# Whether this feature is supported by the C library depends on the used DTLS library.
+dtls-rpk = ["dtls"]
 
 [dependencies]
 openssl-sys = { version = "^0.9.74", optional = true }

--- a/libcoap-sys/build.rs
+++ b/libcoap-sys/build.rs
@@ -27,7 +27,7 @@ use bindgen::{
 use pkg_config::probe_library;
 use version_compare::{Cmp, Version};
 
-/// Features whose availability can be checked during compile time based on defines.
+/// Features whose availability can be checked during compile time based on `#define` directives.
 const COMPILE_TIME_FEATURE_CHECKS: [&str; 16] = [
     "af-unix",
     "async",
@@ -63,14 +63,14 @@ impl Default for LibcoapMetadata {
             package_version: Default::default(),
             version: 0,
             feature_defines_available: false,
-            // COAP_DISABLE_TCP is set if TCP is _not_ supported, assume it is supported otherwise.
+            // By default, TCP is assumed to be supported if COAP_DISABLE_TCP is unset.
             feature_defines: BTreeSet::from(["tcp".to_string()]),
             dtls_backend: None,
         }
     }
 }
 
-/// Implementation of bindgen's [ParseCallbacks] that allow reading some metainformation about the
+/// Implementation of bindgen's [ParseCallbacks] that allow reading some meta-information about the
 /// used libcoap version from its defines (package version, supported features, ...)
 #[derive(Debug, Default)]
 struct CoapDefineParser {
@@ -794,7 +794,7 @@ fn main() {
             println!("cargo:warning=DTLS library used by libcoap does not match chosen one. This might lead to issues.")
         }
     } else {
-        println!("cargo:warning=The used version of libcoap does not provide a coap_defines.h file, either because it is too old (<4.3.5) or because this file is somehow not included. Compile-time feature checks are not available, and the availability of some features (small-stack, IPv4/IPv6,) can not be asserted at all!");
+        println!("cargo:warning=The used version of libcoap does not provide a coap_defines.h file, either because it is too old (<4.3.5) or because this file is somehow not included. Compile-time feature checks are not available, and the availability of some features (small-stack, IPv4/IPv6,) cannot be asserted at all!");
     }
 
     let out_path = PathBuf::from(out_dir);

--- a/libcoap-sys/build.rs
+++ b/libcoap-sys/build.rs
@@ -147,7 +147,7 @@ impl ParseCallbacks for CoapDefineParser {
                 self.defines.borrow_mut().dtls_backend = Some(DtlsBackend::TinyDtls);
                 self.defines.borrow_mut().feature_defines.insert("dtls".to_string());
             },
-            // TODO as soon as we have wolfSSL support in libcoap-sys
+            // TODO(#29): as soon as we have wolfSSL support in libcoap-sys
             /*"COAP_WITH_LIBWOLFSSL" => {
                 self.defines.borrow_mut().dtls_backend = Some(DtlsBackend::WolfSsl);
                 self.defines
@@ -781,10 +781,6 @@ fn main() {
     let libcoap_defines = libcoap_defines.take();
     if libcoap_defines.feature_defines_available {
         println!("cargo:rustc-cfg=feature_checks_available");
-        println!(
-            "cargo:warning=Available features: {:?}",
-            libcoap_defines.feature_defines
-        );
         for feature in COMPILE_TIME_FEATURE_CHECKS {
             let feature_env_var_name = "CARGO_FEATURE_".to_string() + &feature.replace('-', "_").to_uppercase();
             if env::var(&feature_env_var_name).is_ok() && !libcoap_defines.feature_defines.contains(feature) {

--- a/libcoap-sys/build.rs
+++ b/libcoap-sys/build.rs
@@ -302,13 +302,17 @@ fn get_builder_espidf() -> bindgen::Builder {
         .clang_arg("-DESP_PLATFORM")
         .clang_arg("-DLWIP_IPV4=1")
         .clang_arg("-DLWIP_IPV6=1")
+        .clang_arg("-DconfigUSE_PASSIVE_IDLE_HOOK=1")
         .clang_arg(format!("-I{}/components/newlib/platform_include", esp_idf_path))
         .clang_arg(format!("-I{}/components/lwip/port/include", esp_idf_path))
         .clang_arg(format!("-I{}/components/lwip/port/esp32xx/include", esp_idf_path))
         .clang_arg(format!("-I{}/components/lwip/lwip/src/include", esp_idf_path))
         .clang_arg(format!("-I{}/components/lwip/port/freertos/include", esp_idf_path))
         .clang_arg(format!("-I{}/components/esp_system/include", esp_idf_path))
-        .clang_arg(format!("-I{}/components/freertos/config/include/freertos", esp_idf_path))
+        .clang_arg(format!(
+            "-I{}/components/freertos/config/include/freertos",
+            esp_idf_path
+        ))
         .clang_arg(format!("-I{}/components/freertos/esp_additions/include", esp_idf_path))
         .clang_arg(format!(
             "-I{}/components/freertos/esp_additions/include/freertos",
@@ -323,7 +327,10 @@ fn get_builder_espidf() -> bindgen::Builder {
             esp_idf_path, short_target
         )) // for newer espidf
         .clang_arg(format!("-I{}/components/{}/include", esp_idf_path, short_target))
-        .clang_arg(format!("-I{}/components/{}/{}/include", esp_idf_path, short_target, target_mcu))
+        .clang_arg(format!(
+            "-I{}/components/{}/{}/include",
+            esp_idf_path, short_target, target_mcu
+        ))
         .clang_arg(format!("-I{}/components/esp_hw_support/include", esp_idf_path))
         .clang_arg(format!("-I{}/components/esp_common/include", esp_idf_path))
         .clang_arg(format!(

--- a/libcoap-sys/src/lib.rs
+++ b/libcoap-sys/src/lib.rs
@@ -111,7 +111,7 @@ include!(concat!(env!("OUT_DIR"), "\\bindings.rs"));
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[inline]
-#[cfg(inlined_coap_send_rst)]
+#[cfg(not(non_inlined_coap_send_rst))]
 pub unsafe fn coap_send_rst(session: *mut coap_session_t, request: *const coap_pdu_t) -> coap_mid_t {
     coap_send_message_type(session, request, crate::coap_pdu_type_t::COAP_MESSAGE_RST)
 }

--- a/libcoap-sys/src/lib.rs
+++ b/libcoap-sys/src/lib.rs
@@ -151,6 +151,124 @@ pub unsafe fn coap_string_equal_internal(
                 && memcmp(str1_ptr as *const c_void, str2_ptr as *const c_void, str1_len) == 0)
 }
 
+/// Initialize the CoAP library and additionally perform runtime checks to ensure that required
+/// features (as enabled in `Cargo.toml`) are available.
+///
+/// You *should* prefer using this function over [coap_startup], as without calling this function
+/// some of the features enabled using the Cargo features may not actually be available.
+/// (NOTE: However, see the below section on safety).
+///
+/// Either this function or [coap_startup] must be run once before any libcoap function is called.
+///
+/// If you are absolutely 100% certain that all features you require are always available (or are
+/// prepared to deal with error return values/different behavior on your own if they aren't), you
+/// may use [coap_startup] instead.
+///
+/// # SAFETY WARNING
+/// In order to preserve backwards compatibility, this method may (for now) skip the feature checks
+/// altogether if they aren't provided by libcoap (which may be the case for libcoap < 4.3.5rc3).
+///
+/// If you want to be absolutely certain that a given feature is available, you *must* also check
+/// the libcoap version to ensure that it is at least 4.3.5rc3.
+///
+/// This behavior will be changed as soon as libcoap 4.3.5 is released, after which libcoap 4.3.5
+/// will become the minimum supported version and these checks will be mandatory.
+pub fn coap_startup_with_feature_checks() {
+    // only compile checks if they are available for the given libcoap version.
+    #[cfg(feature_checks_available)]
+    {
+        #[cfg(feature = "af-unix")]
+        if unsafe { coap_af_unix_is_supported() != 1 } {
+            panic!("Required feature \"af-unix\" is not supported by libcoap")
+        }
+        #[cfg(feature = "async")]
+        if unsafe { coap_async_is_supported() != 1 } {
+            panic!("Required feature \"async\" is not supported by libcoap")
+        }
+        #[cfg(feature = "client")]
+        if unsafe { coap_client_is_supported() != 1 } {
+            panic!("Required feature \"ipv4\" is not supported by libcoap")
+        }
+        #[cfg(feature = "dtls")]
+        if unsafe { coap_dtls_is_supported() != 1 } {
+            panic!("Required feature \"dtls\" is not supported by libcoap")
+        }
+        #[cfg(feature = "dtls-cid")]
+        if unsafe { coap_dtls_cid_is_supported() != 1 } {
+            panic!("Required feature \"dtls\" is not supported by libcoap")
+        }
+        #[cfg(feature = "dtls-psk")]
+        if unsafe { coap_dtls_psk_is_supported() != 1 } {
+            panic!("Required feature \"dtls\" is not supported by libcoap")
+        }
+        #[cfg(feature = "dtls-pki")]
+        if unsafe { coap_dtls_pki_is_supported() != 1 } {
+            panic!("Required feature \"dtls\" is not supported by libcoap")
+        }
+        #[cfg(feature = "dtls-pkcs11")]
+        if !unsafe { coap_dtls_pkcs11_is_supported() == 1 } {
+            panic!("Required feature \"dtls\" is not supported by libcoap")
+        }
+        #[cfg(feature = "dtls-rpk")]
+        if unsafe { coap_dtls_rpk_is_supported() != 1 } {
+            panic!("Required feature \"dtls\" is not supported by libcoap")
+        }
+        #[cfg(feature = "epoll")]
+        if unsafe { coap_epoll_is_supported() != 1 } {
+            panic!("Required feature \"epoll\" is not supported by libcoap")
+        }
+        #[cfg(feature = "ipv4")]
+        if !unsafe { coap_ipv4_is_supported() == 1 } {
+            panic!("Required feature \"ipv4\" is not supported by libcoap")
+        }
+        #[cfg(feature = "ipv6")]
+        if !unsafe { coap_ipv6_is_supported() == 1 } {
+            panic!("Required feature \"ipv6\" is not supported by libcoap")
+        }
+        #[cfg(feature = "observe-persist")]
+        if unsafe { coap_observe_persist_is_supported() != 1 } {
+            panic!("Required feature \"ipv4\" is not supported by libcoap")
+        }
+        #[cfg(feature = "oscore")]
+        if unsafe { coap_oscore_is_supported() != 1 } {
+            panic!("Required feature \"oscore\" is not supported by libcoap")
+        }
+        #[cfg(feature = "q-block")]
+        if unsafe { coap_q_block_is_supported() != 1 } {
+            panic!("Required feature \"q-block\" is not supported by libcoap")
+        }
+        #[cfg(feature = "server")]
+        if unsafe { coap_server_is_supported() != 1 } {
+            panic!("Required feature \"ipv4\" is not supported by libcoap")
+        }
+        #[cfg(feature = "tcp")]
+        if unsafe { coap_tcp_is_supported() != 1 } {
+            panic!("Required feature \"tcp\" is not supported by libcoap")
+        }
+        #[cfg(feature = "thread-safe")]
+        if unsafe { coap_threadsafe_is_supported() != 1 } {
+            panic!("Required feature \"thread-safe\" is not supported by libcoap")
+        }
+        #[cfg(feature = "tls")]
+        if unsafe { coap_tls_is_supported() != 1 } {
+            panic!("Required feature \"tls\" is not supported by libcoap")
+        }
+        #[cfg(feature = "websockets")]
+        if unsafe { coap_ws_is_supported() != 1 } {
+            panic!("Required feature \"websockets\" is not supported by libcoap")
+        }
+        #[cfg(feature = "secure-websockets")]
+        if unsafe { coap_wss_is_supported() != 1 } {
+            panic!("Required feature \"websockets\" is not supported by libcoap")
+        }
+    }
+    #[cfg(not(feature_checks_available))]
+    {
+        println!("WARNING: coap_startup_with_feature_checks() could not assert the availability of features because the linked version of libcoap is too old (< 4.3.5rc3)!")
+    }
+    unsafe { coap_startup() }
+}
+
 #[cfg(all(test, not(target_os = "espidf")))]
 mod tests {
     use std::{

--- a/libcoap-sys/src/lib.rs
+++ b/libcoap-sys/src/lib.rs
@@ -178,86 +178,107 @@ pub fn coap_startup_with_feature_checks() {
     #[cfg(feature_checks_available)]
     {
         #[cfg(feature = "af-unix")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_af_unix_is_supported() != 1 } {
             panic!("Required feature \"af-unix\" is not supported by libcoap")
         }
         #[cfg(feature = "async")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_async_is_supported() != 1 } {
             panic!("Required feature \"async\" is not supported by libcoap")
         }
         #[cfg(feature = "client")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_client_is_supported() != 1 } {
             panic!("Required feature \"ipv4\" is not supported by libcoap")
         }
         #[cfg(feature = "dtls")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_dtls_is_supported() != 1 } {
             panic!("Required feature \"dtls\" is not supported by libcoap")
         }
         #[cfg(feature = "dtls-cid")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_dtls_cid_is_supported() != 1 } {
             panic!("Required feature \"dtls\" is not supported by libcoap")
         }
         #[cfg(feature = "dtls-psk")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_dtls_psk_is_supported() != 1 } {
             panic!("Required feature \"dtls\" is not supported by libcoap")
         }
         #[cfg(feature = "dtls-pki")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_dtls_pki_is_supported() != 1 } {
             panic!("Required feature \"dtls\" is not supported by libcoap")
         }
         #[cfg(feature = "dtls-pkcs11")]
+        // SAFETY: Function is always safe to call.
         if !unsafe { coap_dtls_pkcs11_is_supported() == 1 } {
             panic!("Required feature \"dtls\" is not supported by libcoap")
         }
         #[cfg(feature = "dtls-rpk")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_dtls_rpk_is_supported() != 1 } {
             panic!("Required feature \"dtls\" is not supported by libcoap")
         }
         #[cfg(feature = "epoll")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_epoll_is_supported() != 1 } {
             panic!("Required feature \"epoll\" is not supported by libcoap")
         }
         #[cfg(feature = "ipv4")]
+        // SAFETY: Function is always safe to call.
         if !unsafe { coap_ipv4_is_supported() == 1 } {
             panic!("Required feature \"ipv4\" is not supported by libcoap")
         }
         #[cfg(feature = "ipv6")]
+        // SAFETY: Function is always safe to call.
         if !unsafe { coap_ipv6_is_supported() == 1 } {
             panic!("Required feature \"ipv6\" is not supported by libcoap")
         }
         #[cfg(feature = "observe-persist")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_observe_persist_is_supported() != 1 } {
             panic!("Required feature \"ipv4\" is not supported by libcoap")
         }
         #[cfg(feature = "oscore")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_oscore_is_supported() != 1 } {
             panic!("Required feature \"oscore\" is not supported by libcoap")
         }
         #[cfg(feature = "q-block")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_q_block_is_supported() != 1 } {
             panic!("Required feature \"q-block\" is not supported by libcoap")
         }
         #[cfg(feature = "server")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_server_is_supported() != 1 } {
             panic!("Required feature \"ipv4\" is not supported by libcoap")
         }
         #[cfg(feature = "tcp")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_tcp_is_supported() != 1 } {
             panic!("Required feature \"tcp\" is not supported by libcoap")
         }
         #[cfg(feature = "thread-safe")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_threadsafe_is_supported() != 1 } {
             panic!("Required feature \"thread-safe\" is not supported by libcoap")
         }
         #[cfg(feature = "tls")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_tls_is_supported() != 1 } {
             panic!("Required feature \"tls\" is not supported by libcoap")
         }
         #[cfg(feature = "websockets")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_ws_is_supported() != 1 } {
             panic!("Required feature \"websockets\" is not supported by libcoap")
         }
         #[cfg(feature = "secure-websockets")]
+        // SAFETY: Function is always safe to call.
         if unsafe { coap_wss_is_supported() != 1 } {
             panic!("Required feature \"websockets\" is not supported by libcoap")
         }
@@ -266,6 +287,7 @@ pub fn coap_startup_with_feature_checks() {
     {
         println!("WARNING: coap_startup_with_feature_checks() could not assert the availability of features because the linked version of libcoap is too old (< 4.3.5rc3)!")
     }
+    // SAFETY: Function is always safe to call.
     unsafe { coap_startup() }
 }
 

--- a/libcoap-sys/src/wrapper.h
+++ b/libcoap-sys/src/wrapper.h
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * wrapper.h - wrapper header to generate libcoap Rust bindings using bindgen
- * This file is part of the libcoap-sys crate, see the README and LICENSE files
- * for more information and terms of use. Copyright © 2021-2023 The NAMIB
- * Project Developers, all rights reserved. See the README as well as the
- * LICENSE file for more information.
+ * This file is part of the libcoap-sys crate, see the README and LICENSE files for
+ * more information and terms of use.
+ * Copyright © 2021-2024 The NAMIB Project Developers, all rights reserved.
+ * See the README as well as the LICENSE file for more information.
  */
 
 #include <coap3/coap.h>

--- a/libcoap-sys/src/wrapper.h
+++ b/libcoap-sys/src/wrapper.h
@@ -8,4 +8,6 @@
  */
 
 #include <coap3/coap.h>
+#if __has_include(<coap3/coap_defines.h>)
 #include <coap3/coap_defines.h>
+#endif

--- a/libcoap-sys/src/wrapper.h
+++ b/libcoap-sys/src/wrapper.h
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * wrapper.h - wrapper header to generate libcoap Rust bindings using bindgen
- * This file is part of the libcoap-sys crate, see the README and LICENSE files for
- * more information and terms of use.
- * Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
- * See the README as well as the LICENSE file for more information.
+ * This file is part of the libcoap-sys crate, see the README and LICENSE files
+ * for more information and terms of use. Copyright © 2021-2023 The NAMIB
+ * Project Developers, all rights reserved. See the README as well as the
+ * LICENSE file for more information.
  */
 
 #include <coap3/coap.h>
-#include <coap_config.h>
+#include <coap3/coap_defines.h>

--- a/libcoap/Cargo.toml
+++ b/libcoap/Cargo.toml
@@ -30,7 +30,6 @@ dtls_mbedtls_vendored = ["dtls_mbedtls", "libcoap-sys/dtls_backend_mbedtls_vendo
 tcp = ["libcoap-sys/tcp"]
 tls = ["libcoap-sys/tls"]
 rand = ["dep:rand", "dep:rand_core"]
-nightly = []
 vendored = ["libcoap-sys/vendored"]
 
 [dependencies]

--- a/libcoap/Cargo.toml
+++ b/libcoap/Cargo.toml
@@ -2,7 +2,7 @@
 # Cargo.toml for libcoap
 # This file is part of the libcoap-rs crate, see the README and LICENSE files for
 # more information and terms of use.
-# Copyright © 2021-2023 The NAMIB Project Developers, all rights reserved.
+# Copyright © 2021-2024 The NAMIB Project Developers, all rights reserved.
 
 [package]
 name = "libcoap-rs"
@@ -18,7 +18,7 @@ keywords = ["coap", "libcoap"]
 resolver = "2"
 
 [features]
-default = ["dtls", "tcp", "dtls_openssl", "vendored"]
+default = ["dtls", "tcp", "dtls_openssl", "vendored", "libcoap-sys/default"]
 dtls = ["libcoap-sys/dtls"]
 dtls_tinydtls = ["libcoap-sys/dtls_backend_tinydtls"]
 dtls_tinydtls_vendored = ["dtls_tinydtls", "libcoap-sys/dtls_backend_tinydtls_vendored"]
@@ -28,6 +28,7 @@ dtls_gnutls = ["libcoap-sys/dtls_backend_gnutls"]
 dtls_mbedtls = ["libcoap-sys/dtls_backend_mbedtls"]
 dtls_mbedtls_vendored = ["dtls_mbedtls", "libcoap-sys/dtls_backend_mbedtls_vendored"]
 tcp = ["libcoap-sys/tcp"]
+tls = ["libcoap-sys/tls"]
 rand = ["dep:rand", "dep:rand_core"]
 nightly = []
 vendored = ["libcoap-sys/vendored"]
@@ -41,6 +42,9 @@ url = { version = "^2.2", optional = true }
 rand = { version = "^0.8.4", optional = true }
 rand_core = { version = "0.6.4", optional = true }
 thiserror = "^1.0"
+
+[build-dependencies]
+version-compare = "0.2.0"
 
 [package.metadata.docs.rs]
 features = ["dtls", "dtls_openssl", "vendored", "url"]

--- a/libcoap/build.rs
+++ b/libcoap/build.rs
@@ -1,0 +1,16 @@
+use version_compare::{Cmp, Version};
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(dtls_ec_jpake_support)");
+    println!("cargo::rustc-check-cfg=cfg(dtls_cid_support)");
+    let libcoap_version =
+        std::env::var("DEP_COAP_3_LIBCOAP_VERSION").expect("unable to determine library version of libcoap");
+    let version = Version::from(libcoap_version.as_ref()).expect("invalid libcoap version");
+    match version.compare(Version::from("4.3.5rc3").unwrap()) {
+        Cmp::Gt | Cmp::Eq => {
+            println!("cargo:rustc-cfg=dtls_ec_jpake_support");
+            println!("cargo:rustc-cfg=dtls_cid_support");
+        },
+        _ => {},
+    }
+}

--- a/libcoap/build.rs
+++ b/libcoap/build.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-2-CLAUSE
+
 use version_compare::{Cmp, Version};
 
 fn main() {

--- a/libcoap/build.rs
+++ b/libcoap/build.rs
@@ -3,14 +3,14 @@ use version_compare::{Cmp, Version};
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(dtls_ec_jpake_support)");
     println!("cargo::rustc-check-cfg=cfg(dtls_cid_support)");
-    let libcoap_version =
-        std::env::var("DEP_COAP_3_LIBCOAP_VERSION").expect("unable to determine library version of libcoap");
-    let version = Version::from(libcoap_version.as_ref()).expect("invalid libcoap version");
-    match version.compare(Version::from("4.3.5rc3").unwrap()) {
-        Cmp::Gt | Cmp::Eq => {
-            println!("cargo:rustc-cfg=dtls_ec_jpake_support");
-            println!("cargo:rustc-cfg=dtls_cid_support");
-        },
-        _ => {},
+    if let Ok(libcoap_version) = std::env::var("DEP_COAP_3_LIBCOAP_VERSION") {
+        let version = Version::from(libcoap_version.as_ref()).expect("invalid libcoap version");
+        match version.compare(Version::from("4.3.5rc3").unwrap()) {
+            Cmp::Gt | Cmp::Eq => {
+                println!("cargo:rustc-cfg=dtls_ec_jpake_support");
+                println!("cargo:rustc-cfg=dtls_cid_support");
+            },
+            _ => {},
+        }
     }
 }

--- a/libcoap/src/context.rs
+++ b/libcoap/src/context.rs
@@ -337,7 +337,13 @@ impl CoapContext<'_> {
                     inner_ref.raw_context,
                     Box::into_raw(Box::new(coap_dtls_spsk_t {
                         version: COAP_DTLS_SPSK_SETUP_VERSION as u8,
+                        #[cfg(not(dtls_ec_jpake_support))]
                         reserved: [0; 7],
+                        #[cfg(dtls_ec_jpake_support)]
+                        reserved: [0; 6],
+                        #[cfg(dtls_ec_jpake_support)]
+                        // TODO allow enabling this?
+                        ec_jpake: 0,
                         validate_id_call_back: Some(dtls_server_id_callback),
                         id_call_back_arg: inner_ref.raw_context as *mut c_void,
                         validate_sni_call_back: {

--- a/libcoap/src/context.rs
+++ b/libcoap/src/context.rs
@@ -49,9 +49,7 @@ static COAP_STARTUP_ONCE: Once = Once::new();
 
 #[inline(always)]
 pub(crate) fn ensure_coap_started() {
-    COAP_STARTUP_ONCE.call_once(|| unsafe {
-        coap_startup_with_feature_checks();
-    });
+    COAP_STARTUP_ONCE.call_once(coap_startup_with_feature_checks);
 }
 
 #[derive(Debug)]
@@ -345,7 +343,7 @@ impl CoapContext<'_> {
                         #[cfg(dtls_ec_jpake_support)]
                         reserved: [0; 6],
                         #[cfg(dtls_ec_jpake_support)]
-                        // TODO allow enabling this?
+                        // TODO(#30) allow enabling this
                         ec_jpake: 0,
                         validate_id_call_back: Some(dtls_server_id_callback),
                         id_call_back_arg: inner_ref.raw_context as *mut c_void,

--- a/libcoap/src/lib.rs
+++ b/libcoap/src/lib.rs
@@ -7,8 +7,6 @@
  * See the README as well as the LICENSE file for more information.
  */
 
-#![cfg_attr(feature = "nightly", feature(trait_upcasting))]
-
 //! A safe wrapper around the libcoap C library.
 //!
 //! This wrapper allows for safe and idiomatic usage of the libcoap C library in Rust.
@@ -40,13 +38,13 @@
 //! # Building
 //! libcoap-rs can be linked to either an included version of libcoap or to a version provided by
 //! the environment.
-//! By default, it will use the vendored version, which can be disabled by disabling the default 
+//! By default, it will use the vendored version, which can be disabled by disabling the default
 //! feature `vendored`.
-//! 
-//! In order to use DTLS, a DTLS library must be chosen, see the later section on using 
+//!
+//! In order to use DTLS, a DTLS library must be chosen, see the later section on using
 //! cryptography for more information.
 //!
-//! Some (but not all) of the available DTLS libraries may also be vendored using the 
+//! Some (but not all) of the available DTLS libraries may also be vendored using the
 //! `dtls_[LIBRARY]_vendored` feature.
 //!
 //! ## Building on the ESP32
@@ -58,11 +56,11 @@
 //! In order to build for the ESP, ensure that the following preconditions are met:
 //!
 //! - The version of `esp-idf-sys` used by your crate matches the one used by `libcoap-sys`.
-//! - Ensure that your `sdkconfig.defaults` enables the features required by your chosen 
+//! - Ensure that your `sdkconfig.defaults` enables the features required by your chosen
 //!   feature set of `libcoap-rs`
 //! - Ensure that the ESP-IDF version you link against is supported. `libcoap-rs` _should_
-//!   compile on at least ESP-IDF 5.1.3 and 5.3. 
-//!   If it does not (or you require support for newer versions of ESP-IDF), please open an issue 
+//!   compile on at least ESP-IDF 5.1.3 and 5.3.
+//!   If it does not (or you require support for newer versions of ESP-IDF), please open an issue
 //!   in the [`libcoap-rs` issue tracker](https://github.com/namib-project/libcoap-rs/issues).
 //!
 //! An example for a typical excerpt from `sdkconfig.defaults` can be found here:
@@ -70,7 +68,7 @@
 //! # libcoap base functionality (client and server)
 //! CONFIG_COAP_SERVER_SUPPORT=y
 //! CONFIG_COAP_CLIENT_SUPPORT=y
-//! 
+//!
 //! # enable DTLS in libcoap
 //! CONFIG_COAP_MBEDTLS_PSK=y
 //! CONFIG_COAP_MBEDTLS_PKI=y

--- a/libcoap/src/message/mod.rs
+++ b/libcoap/src/message/mod.rs
@@ -39,6 +39,7 @@ use crate::{
     session::CoapSessionCommon,
     types::CoapMessageId,
 };
+use crate::context::ensure_coap_started;
 use crate::protocol::{Echo, Oscore, RequestTag};
 use crate::types::{
     decode_var_len_u16, decode_var_len_u32, decode_var_len_u8, encode_var_len_u16, encode_var_len_u32,
@@ -373,6 +374,7 @@ pub struct CoapMessage {
 impl CoapMessage {
     /// Creates a new CoAP message with the given type and code.
     pub fn new(type_: CoapMessageType, code: CoapMessageCode) -> CoapMessage {
+        ensure_coap_started();
         CoapMessage {
             type_,
             code,
@@ -388,6 +390,7 @@ impl CoapMessage {
     /// # Safety
     /// raw_pdu must point to a valid instance of coap_pdu_t.
     pub unsafe fn from_raw_pdu(raw_pdu: *const coap_pdu_t) -> Result<CoapMessage, MessageConversionError> {
+        ensure_coap_started();
         let mut option_iter = MaybeUninit::zeroed();
         coap_option_iterator_init(raw_pdu, option_iter.as_mut_ptr(), std::ptr::null());
         let mut option_iter = option_iter.assume_init();

--- a/libcoap/src/prng.rs
+++ b/libcoap/src/prng.rs
@@ -24,6 +24,7 @@ use rand::{CryptoRng, RngCore};
 
 use libcoap_sys::{coap_prng, coap_prng_init, coap_set_prng};
 
+use crate::context::ensure_coap_started;
 use crate::error::RngError;
 
 // TODO If we can assert that libcoap's own thread-safety features are enabled at some point, we
@@ -53,6 +54,7 @@ static COAP_RNG_ACCESS_MUTEX: Mutex<()> = Mutex::new(());
 /// # Result::<(), RngError>::Ok(())
 /// ```
 pub fn coap_prng_try_fill(dest: &mut [u8]) -> Result<(), RngError> {
+    ensure_coap_started();
     let _acc_mutex = COAP_RNG_ACCESS_MUTEX.lock()?;
     // SAFETY: Supplied pointer and length describe the provided slice.
     match unsafe { coap_prng(dest.as_mut_ptr() as *mut c_void, dest.len()) } {
@@ -100,6 +102,7 @@ impl RngCore for CoapRng {
 /// May return an error if the mutex for seeding the PRNG is poisoned, i.e. there was some panic
 /// in a previous attempt of seeding the PRNG.
 pub fn seed_coap_prng(seed: c_uint) -> Result<(), RngError> {
+    ensure_coap_started();
     let guard = COAP_RNG_SEED_MUTEX.lock()?;
     unsafe {
         coap_prng_init(seed);
@@ -160,6 +163,7 @@ pub fn seed_coap_prng(seed: c_uint) -> Result<(), RngError> {
 /// ```
 #[cfg(feature = "rand")]
 pub fn set_coap_prng<RNG: RngCore + CryptoRng + Send + Sync + 'static>(rng: RNG) -> Result<(), RngError> {
+    ensure_coap_started();
     let mut guard = COAP_RNG_FN_MUTEX.lock()?;
     *guard = Some(Box::new(rng));
     // SAFETY: Pointer is valid and pointed to function does what libcoap expects.

--- a/libcoap/src/prng.rs
+++ b/libcoap/src/prng.rs
@@ -15,14 +15,19 @@
 //! [rand] crate that allow using the libcoap PRNG as a [rand::Rng] or setting the libcoap PRNG to
 //! an existing [rand::Rng].
 
-use std::ffi::{c_int, c_uint, c_void};
+use std::ffi::{c_uint, c_void};
+#[cfg(feature = "rand")]
+use std::ffi::c_int;
 use std::sync::Mutex;
 
+#[cfg(feature = "rand")]
 use libc::size_t;
 #[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
-use libcoap_sys::{coap_prng, coap_prng_init, coap_set_prng};
+use libcoap_sys::{coap_prng, coap_prng_init};
+#[cfg(feature = "rand")]
+use libcoap_sys::coap_set_prng;
 
 use crate::context::ensure_coap_started;
 use crate::error::RngError;

--- a/libcoap/src/resource.rs
+++ b/libcoap/src/resource.rs
@@ -27,6 +27,7 @@ use libcoap_sys::{
 };
 
 use crate::{error::MessageConversionError, message::CoapMessage, protocol::CoapRequestCode};
+use crate::context::ensure_coap_started;
 use crate::mem::{CoapFfiRcCell, DropInnerExclusively};
 use crate::message::CoapMessageCommon;
 use crate::message::request::CoapRequest;
@@ -240,6 +241,7 @@ impl<D: Any + ?Sized + Debug> CoapResource<D> {
     /// The `notify_con` parameter specifies whether observe notifications originating from this
     /// resource are sent as confirmable or non-confirmable.
     pub fn new<C: Into<Box<D>>>(uri_path: &str, user_data: C, notify_con: bool) -> CoapResource<D> {
+        ensure_coap_started();
         let inner = unsafe {
             let uri_path = coap_new_str_const(uri_path.as_ptr(), uri_path.len());
             let raw_resource = coap_resource_init(
@@ -491,6 +493,7 @@ impl<D: 'static + ?Sized + Debug> CoapRequestHandler<D> {
             response_pdu: *mut coap_pdu_t,
         ),
     ) -> CoapRequestHandler<D> {
+        ensure_coap_started();
         let handler_fn: Option<Box<dyn FnMut(&CoapResource<D>, &mut CoapServerSession, &CoapRequest, CoapResponse)>> =
             None;
         CoapRequestHandler {

--- a/libcoap/src/session/client.rs
+++ b/libcoap/src/session/client.rs
@@ -67,7 +67,18 @@ impl CoapClientSession<'_> {
         let id = crypto_provider.provide_default_info();
         let client_setup_data = Box::into_raw(Box::new(coap_dtls_cpsk_t {
             version: COAP_DTLS_SPSK_SETUP_VERSION as u8,
+            #[cfg(not(any(dtls_ec_jpake_support, dtls_cid_support)))]
             reserved: [0; 7],
+            #[cfg(all(any(dtls_ec_jpake_support, dtls_cid_support), not(all(dtls_ec_jpake_support, dtls_cid_support))))]
+            reserved: [0; 6],
+            #[cfg(all(dtls_ec_jpake_support, dtls_cid_support))]
+            reserved: [0; 5],
+            #[cfg(dtls_ec_jpake_support)]
+            // TODO allow enabling this?
+            ec_jpake: 0,
+            // TODO allow enabling this?
+            #[cfg(dtls_cid_support)]
+            use_cid: 0,
             validate_ih_call_back: {
                 // Unsupported by MbedTLS
                 #[cfg(not(feature = "dtls_mbedtls"))]

--- a/libcoap/src/types.rs
+++ b/libcoap/src/types.rs
@@ -137,7 +137,10 @@ impl From<SocketAddr> for CoapAddress {
 
                     *coap_addr.addr.sin.as_mut() = sockaddr_in {
                         #[cfg(any(
-                            bsd,
+                            target_os = "freebsd",
+                            target_os = "dragonfly",
+                            target_os = "openbsd",
+                            target_os = "netbsd",
                             target_os = "aix",
                             target_os = "haiku",
                             target_os = "hurd",
@@ -166,7 +169,10 @@ impl From<SocketAddr> for CoapAddress {
 
                     *coap_addr.addr.sin6.as_mut() = sockaddr_in6 {
                         #[cfg(any(
-                            bsd,
+                            target_os = "freebsd",
+                            target_os = "dragonfly",
+                            target_os = "openbsd",
+                            target_os = "netbsd",
                             target_os = "aix",
                             target_os = "haiku",
                             target_os = "hurd",

--- a/libcoap/src/types.rs
+++ b/libcoap/src/types.rs
@@ -735,9 +735,9 @@ impl CoapUri {
         parsing_fn: unsafe extern "C" fn(*const u8, usize, *mut coap_uri_t) -> c_int,
         is_proxy: bool,
     ) -> Result<CoapUri, UriParsingError> {
+        ensure_coap_started();
         let mut uri = Self::create_unparsed_uri(uri_str, is_proxy);
 
-        ensure_coap_started();
         // SAFETY: The provided pointers to raw_uri and uri_str are valid.
         // Because uri_str is pinned (and its type is not Unpin), the pointer locations are always
         // valid while this object lives, therefore the resulting coap_uri_t remains valid for the

--- a/libcoap/src/types.rs
+++ b/libcoap/src/types.rs
@@ -41,6 +41,7 @@ use libcoap_sys::{
 };
 use libcoap_sys::coap_uri_scheme_t::{COAP_URI_SCHEME_COAP_WS, COAP_URI_SCHEME_COAPS_WS};
 
+use crate::context::ensure_coap_started;
 use crate::error::UriParsingError;
 use crate::message::CoapOption;
 use crate::protocol::UriPort;
@@ -736,6 +737,7 @@ impl CoapUri {
     ) -> Result<CoapUri, UriParsingError> {
         let mut uri = Self::create_unparsed_uri(uri_str, is_proxy);
 
+        ensure_coap_started();
         // SAFETY: The provided pointers to raw_uri and uri_str are valid.
         // Because uri_str is pinned (and its type is not Unpin), the pointer locations are always
         // valid while this object lives, therefore the resulting coap_uri_t remains valid for the


### PR DESCRIPTION
This PR adds startup and compile-time checks to `libcoap-rs` and `libcoap-sys` that ensure that features enabled by `Cargo.toml` are actually available.

This is now possible thanks to the changes made in obgm/libcoap#1488, which adds the required defines for compile-time and functions for startup checks.

Closes #20