### PR TITLE
chore(README.md): remove obsolete square brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # libcoap-rs
 
 [![CI Status](https://github.com/namib-project/libcoap-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/namib-project/libcoap-rs/actions/workflows/ci.yml)
-[![Coverage](https://raw.githubusercontent.com/namib-project/libcoap-rs/_xml_coverage_reports/data/main/badge.svg)]
+![Coverage](https://raw.githubusercontent.com/namib-project/libcoap-rs/_xml_coverage_reports/data/main/badge.svg)
 
 Raw binding and safe wrapper for the [libcoap CoAP libary](https://github.com/obgm/libcoap).
 


### PR DESCRIPTION
Looking at the README file, I noticed that there currently are obsolete square brackets around the code coverage badge. This PR removes them. However, it might make sense to also wrap the badge with a proper link (there is anything to link to here).