### PR TITLE
Set correct buffer size in into_options() on libcoap<4.3.5rc2

### DIFF
--- a/.idea/runConfigurations/Test.xml
+++ b/.idea/runConfigurations/Test.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="test -p libcoap-rs " />
+    <option name="command" value="test -p libcoap-rs" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/libcoap/build.rs
+++ b/libcoap/build.rs
@@ -5,8 +5,19 @@ use version_compare::{Cmp, Version};
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(dtls_ec_jpake_support)");
     println!("cargo::rustc-check-cfg=cfg(dtls_cid_support)");
+    println!("cargo::rustc-check-cfg=cfg(coap_uri_buf_unused)");
     if let Ok(libcoap_version) = std::env::var("DEP_COAP_3_LIBCOAP_VERSION") {
         let version = Version::from(libcoap_version.as_ref()).expect("invalid libcoap version");
+        // libcoap >= 4.3.5rc2 no longer uses the buf and buflen parameters in
+        // coap_uri_into_options(), so we can optimize them out and save some memory.
+        match version.compare(Version::from("4.3.5rc2").unwrap()) {
+            Cmp::Gt | Cmp::Eq => {
+                println!("cargo:rustc-cfg=coap_uri_buf_unused");
+            },
+            _ => {},
+        }
+        // libcoap >= 4.3.5rc3 supports DTLS EC JPAKE and connection ID extensions, which adds
+        // additional fields to some DTLS configuration structs.
         match version.compare(Version::from("4.3.5rc3").unwrap()) {
             Cmp::Gt | Cmp::Eq => {
                 println!("cargo:rustc-cfg=dtls_ec_jpake_support");

--- a/libcoap/src/message/request.rs
+++ b/libcoap/src/message/request.rs
@@ -428,7 +428,7 @@ impl CoapRequest {
     /// Converts this request into a [CoapMessage] that can be sent over a [CoapSession](crate::session::CoapSession).
     pub fn into_message(mut self) -> CoapMessage {
         if self.uri.is_proxy() {
-            self.pdu.add_option(CoapOption::ProxyUri(
+            self.pdu.add_option(CoapOption::ProxyScheme(
                 self.uri.scheme().expect("Parsed CoAP URI must have scheme").to_string(),
             ))
         }


### PR DESCRIPTION
Versions of libcoap older than 4.3.5rc2 used a user-provided buffer for temporarily storing the options during conversion.

This buffer, however, must be larger than what the [libcoap documentation originally suggested](https://libcoap.net/doc/reference/4.3.4/group__uri__parse.html#gab12de398f21df10012700359bfdd92ad), as this buffer area must also hold the option headers.
If this is not done, trailing elements of the URI are silently removed.

This PR increases the used buffer size for this temporary buffer to a value that should be large enough to store all options that could be created from this URI.

Additionally, it adds a check for newer libcoap versions that don't use this buffer anymore.
In that case, we just pass an empty buffer instead, saving memory and avoiding some iterations over the URI path and query string to determine the buffer size.