### PR TITLE
Add support for linking against wolfSSL provided by wolfssl-sys

### DIFF
--- a/libcoap-sys/Cargo.toml
+++ b/libcoap-sys/Cargo.toml
@@ -60,9 +60,13 @@ dtls-openssl-sys-vendored = ["dtls-openssl-sys", "openssl-sys/vendored"]
 dtls-mbedtls-sys = ["dep:mbedtls-sys-auto"]
 # Allows using the version of TinyDTLS provided by tinydtls-sys instead of a system-provided one.
 # Note that this does not enforce the use of TinyDTLS in libcoap, see the crate-level documentation for more info.
-dtls-tinydtls-sys = ["dep:tinydtls-sys", "tinydtls-sys/ecc", "tinydtls-sys/psk"]
+dtls-tinydtls-sys = ["dep:tinydtls-sys"]
 # Tell the tinydtls-sys version that is possibly used by libcoap-sys to use the vendored version of its library.
 dtls-tinydtls-sys-vendored = ["dtls-tinydtls-sys", "tinydtls-sys/vendored"]
+# Allows using the version of WolfSSL provided by wolfssl-sys instead of a system-provided one.
+# Note that this does not enforce the use of WolfSSL in libcoap, see the crate-level documentation for more info.
+dtls-wolfssl-sys = ["dep:wolfssl-sys"]
+
 
 # Enabling this feature will allow libcoap-sys to be built with and statically linked to a vendored version of libcoap,
 # This way, it is no longer required to have libcoap installed to use this crate.
@@ -143,7 +147,8 @@ dtls-rpk = ["dtls"]
 [dependencies]
 openssl-sys = { version = "^0.9.74", optional = true }
 mbedtls-sys-auto = { version = "^2.26", optional = true }
-tinydtls-sys = { version = "^0.2.0", default-features = false, optional = true }
+wolfssl-sys = { version = "2.0.0", git = "https://github.com/namib-project/wolfssl-rs.git", branch = "add_sys_cargo_metadata", optional = true, features = ["aesccm", "hmac", "psk", "opensslall", "ex_data", "alpn", "dh"] }
+tinydtls-sys = { version = "^0.2.0", default-features = false, optional = true, features = ["ecc", "psk"] }
 
 [target.'cfg(target_os="espidf")'.dependencies]
 esp-idf-sys = { version = "0.36.1" }

--- a/libcoap-sys/build/main.rs
+++ b/libcoap-sys/build/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
     println!("cargo::rustc-check-cfg=cfg(esp_idf_comp_espressif__coap_enabled)");
     // Indicates the DTLS library crate that was linked against, if a library version vendored by
     // another crate was used.
-    println!("cargo:rustc-check-cfg=cfg(used_dtls_crate, values(\"mbedtls\", \"tinydtls\", \"openssl\"))");
+    println!("cargo:rustc-check-cfg=cfg(used_dtls_crate, values(\"mbedtls\", \"tinydtls\", \"openssl\", \"wolfssl\"))");
     // Indicates the DTLS backend used, if any.
     println!("cargo:rustc-check-cfg=cfg(dtls_backend, values(\"mbedtls\", \"tinydtls\", \"openssl\", \"gnutls\", \"wolfssl\"))");
     // The detected libcoap version, if any.

--- a/libcoap-sys/src/lib.rs
+++ b/libcoap-sys/src/lib.rs
@@ -335,6 +335,8 @@ use openssl_sys as _;
 #[allow(unused_imports)]
 #[cfg(used_dtls_crate = "tinydtls")]
 use tinydtls_sys as _;
+#[cfg(used_dtls_crate = "wolfssl")]
+use wolfssl_sys as _;
 
 // Add check whether the libcoap component is enabled when building for the ESP-IDF.
 #[cfg(all(target_os = "espidf", not(esp_idf_comp_espressif__coap_enabled)))]


### PR DESCRIPTION
This PR allows the vendored version of `libcoap` to link against the version of wolfSSL that is used by the `wolfssl-sys` crate.
This change required some modifications to `wolfssl-sys` in order to expose the library paths to us and enable features necessary for libcoap, which is why it currently uses our own fork of `wolfssl-sys`.

Closes #29.