### PR TITLE
fix: bump rand(_core) and adjust integration to fix GHSA-cq8v-f236-94qc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,17 +549,6 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1112,20 +1101,19 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1133,11 +1121,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom",
 ]
 
 [[package]]
@@ -1384,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -1483,12 +1471,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/devenv.lock
+++ b/devenv.lock
@@ -35,9 +35,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1769939035,
@@ -107,6 +105,21 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1776255774,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1767052823,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
@@ -126,7 +139,7 @@
         "git-hooks": "git-hooks",
         "mk-shell-bin": "mk-shell-bin",
         "nix2container": "nix2container",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": [
           "git-hooks"
         ],

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,4 +1,6 @@
 inputs:
+  git-hooks:
+    url: github:cachix/git-hooks.nix
   mk-shell-bin:
     url: github:rrbutani/nix-mk-shell-bin
   nix2container:

--- a/libcoap/Cargo.toml
+++ b/libcoap/Cargo.toml
@@ -20,10 +20,8 @@ authors = ["Hugo Hakim Damer <hdamer@uni-bremen.de>"]
 categories = ["api-bindings", "network-programming", "embedded"]
 keywords = ["coap", "libcoap"]
 resolver = "2"
-# Current reason for MSRV (please update when increasing MSRV): bindgen generates unsafe extern "C" blocks, which are 
-# not supported on Rust < 1.82, and Rust < 1.84 is not MSRV aware, so we can't just increase libcoap-sys's MSRV.
-# See also: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html
-rust-version = "1.82.0"
+# Current reason for MSRV (please update when increasing MSRV): TypeId::of is not const prior to 1.91.0.
+rust-version = "1.91.0"
 
 [features]
 default = ["dtls-psk", "tcp"]
@@ -48,8 +46,8 @@ libcoap-sys = { version = "^0.2.2", path = "../libcoap-sys", default-features = 
 num-derive = { version = "^0.3.3" }
 num-traits = { version = "^0.2.14" }
 url = { version = "^2.2", optional = true }
-rand = { version = "^0.8.4", optional = true }
-rand_core = { version = "0.6.4", optional = true }
+rand = { version = "0.9.3", optional = true }
+rand_core = { version = "0.9.0", optional = true }
 thiserror = "^1.0"
 
 [build-dependencies]

--- a/libcoap/src/error.rs
+++ b/libcoap/src/error.rs
@@ -142,6 +142,9 @@ pub enum RngError {
     /// RNG mutex is poisoned (panic in another thread while calling RNG function).
     #[error("CoAP RNG configuration error: global RNG mutex is poisoned")]
     GlobalMutexPoisonError,
+    /// Attempted to set CoapRng as RNG provided to libcoap.
+    #[error("CoAP RNG configuration error: attempted to provide libcoap's own RNG wrapper to itself")]
+    CoapRngAsCustomRng,
 }
 
 impl<T> From<PoisonError<T>> for RngError {

--- a/libcoap/src/prng.rs
+++ b/libcoap/src/prng.rs
@@ -16,26 +16,18 @@
 //! [rand] crate that allow using the libcoap PRNG as a [rand::Rng] or setting the libcoap PRNG to
 //! an existing [rand::Rng].
 
-#[cfg(feature = "rand")]
-use std::ffi::c_int;
 use std::{
     ffi::{c_uint, c_void},
     sync::Mutex,
 };
 
-#[cfg(feature = "rand")]
-use libcoap_sys::coap_set_prng;
 use libcoap_sys::{coap_prng, coap_prng_init};
-#[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
 
 use crate::{context::ensure_coap_started, error::RngError};
 
 // TODO If we can assert that libcoap's own thread-safety features are enabled at some point, we
 //      don't need these mutexes.
 static COAP_RNG_SEED_MUTEX: Mutex<()> = Mutex::new(());
-#[cfg(feature = "rand")]
-static COAP_RNG_FN_MUTEX: Mutex<Option<Box<dyn RngCore + Send + Sync>>> = Mutex::new(None);
 static COAP_RNG_ACCESS_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Attempts to fill `dest` with random bytes using libcoap's PRNG.
@@ -66,38 +58,6 @@ pub fn coap_prng_try_fill(dest: &mut [u8]) -> Result<(), RngError> {
         _v => Err(RngError::Unknown),
     }
 }
-/// Implementation of the [rand::RngCore] trait based on libcoap's PRNG.
-///
-/// Important: *DO NOT* provide an instance of [CoapRng] to [set_coap_prng]! This will probably lead
-/// to a stack overflow, as [CoapRng] would recursively call into itself to generate random bytes.
-#[cfg(feature = "rand")]
-pub struct CoapRng {}
-
-#[cfg(feature = "rand")]
-impl RngCore for CoapRng {
-    fn next_u32(&mut self) -> u32 {
-        rand_core::impls::next_u32_via_fill(self)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_fill(self)
-    }
-
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.try_fill_bytes(dest)
-            .expect("error while generating bytes from libcoap RNG")
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        coap_prng_try_fill(dest).map_err(|e| rand::Error::new(e))
-    }
-}
-
-// For now, we can't implement this, as libcoap falls back to the not cryptographically secure
-// rand()/srand() if it can't find a cryptographically secure PRNG.
-// Should be reconsidered either if libcoap removes this fallback or if we can detect whether the
-// fallback was used.
-//impl CryptoRng for CoapRng {}
 
 /// Seeds the default PRNG of libcoap with the provided seed.
 ///
@@ -115,84 +75,170 @@ pub fn seed_coap_prng(seed: c_uint) -> Result<(), RngError> {
     Ok(())
 }
 
-/// Configures libcoap to use the provided `rng` for pseudo-random number generation instead of its
-/// default PRNG.
-///
-/// The provided PRNG will be used globally across all contexts.
-///
-/// # Errors
-///
-/// May return an error if the underlying mutex protecting the RNG is poisoned, i.e. a thread
-/// panicked while holding the lock (which should only happen if the previously set RNG panicked).
-///
-/// # Example
-///
-/// ```
-/// use rand_core::{CryptoRng, Error, RngCore};
-/// use libcoap_rs::error::RngError;
-/// use libcoap_rs::prng::{coap_prng_try_fill, set_coap_prng};
-///
-/// pub struct NullRng {}
-///
-/// impl RngCore for NullRng {
-///     fn next_u32(&mut self) -> u32 {
-///         0
-///     }
-///
-///     fn next_u64(&mut self) -> u64 {
-///         0
-///     }
-///
-///     fn fill_bytes(&mut self, dest: &mut [u8]) {
-///         dest.fill(0);
-///     }
-///
-///     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-///         dest.fill(0);
-///         Ok(())
-///     }
-/// }
-///
-/// // Obviously, this is just for demonstration purposes and should not actually be done.
-/// impl CryptoRng for NullRng {}
-///
-/// set_coap_prng(NullRng{})?;
-/// let mut token = [1u8; 8];
-/// coap_prng_try_fill(&mut token)?;
-///
-/// assert_eq!(&token, &[0u8; 8]);
-///
-///
-/// # Result::<(), RngError>::Ok(())
-/// ```
 #[cfg(feature = "rand")]
-pub fn set_coap_prng<RNG: RngCore + CryptoRng + Send + Sync + 'static>(rng: RNG) -> Result<(), RngError> {
-    ensure_coap_started();
-    let mut guard = COAP_RNG_FN_MUTEX.lock()?;
-    *guard = Some(Box::new(rng));
-    // SAFETY: Pointer is valid and pointed to function does what libcoap expects.
-    unsafe {
-        coap_set_prng(Some(prng_callback));
-    }
-    drop(guard);
-    Ok(())
-}
+pub use rand_integration::*;
 
-/// Callback provided to libcoap for generating random numbers.
-///
-/// # Safety
-///
-/// This function is intended as a [libcoap_sys::coap_rand_func_t], therefore `out` should be valid
-/// and point to the start of an area of memory that can be filled with `len` bytes.
+/// Module containing integration code with the [rand] crate.
 #[cfg(feature = "rand")]
-unsafe extern "C" fn prng_callback(out: *mut c_void, len: usize) -> c_int {
-    let out_slice = std::slice::from_raw_parts_mut(out as *mut u8, len);
-    match COAP_RNG_FN_MUTEX.lock() {
-        Ok(mut rng_fn) => rng_fn
-            .as_mut()
-            .expect("rng_callback has been set, but no RNG was set")
-            .try_fill_bytes(out_slice)
-            .map_or(0, |_| 1),
-        Err(_e) => 0,
+mod rand_integration {
+    use core::{
+        any::TypeId,
+        ffi::{c_int, c_void},
+    };
+    use std::sync::Mutex;
+
+    use libcoap_sys::coap_set_prng;
+    use rand_core::{CryptoRng, TryRngCore, UnwrapErr, UnwrapMut};
+
+    use crate::{context::ensure_coap_started, error::RngError, prng::coap_prng_try_fill};
+
+    static COAP_RNG_FN_MUTEX: Mutex<Option<Box<dyn ErrorErasingTryRngCore + Send + Sync>>> = Mutex::new(None);
+
+    /// Implementation of the [rand::TryRngCore] trait based on libcoap's PRNG.
+    pub struct CoapRng {}
+
+    impl TryRngCore for CoapRng {
+        type Error = RngError;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            // This is the same as rand_core::impls::next_u32_via_fill(self), but with
+            // support for returning errors.
+            let mut buf = [0; 4];
+            self.try_fill_bytes(&mut buf)?;
+            Ok(u32::from_le_bytes(buf))
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            // This is the same as rand_core::impls::next_u64_via_fill(self), but with
+            // support for returning errors.
+            let mut buf = [0; 8];
+            self.try_fill_bytes(&mut buf)?;
+            Ok(u64::from_le_bytes(buf))
+        }
+
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), RngError> {
+            coap_prng_try_fill(dest)
+        }
+    }
+
+    // For now, we can't implement this, as libcoap falls back to the not cryptographically secure
+    // rand()/srand() if it can't find a cryptographically secure PRNG.
+    // Should be reconsidered either if libcoap removes this fallback or if we can detect whether the
+    // fallback was used.
+    //impl CryptoRng for CoapRng {}
+
+    /// Configures libcoap to use the provided `rng` for pseudo-random number generation instead of its
+    /// default PRNG.
+    ///
+    /// The provided PRNG will be used globally across all contexts.
+    ///
+    /// Important: *DO NOT* provide an instance of [CoapRng] to [set_coap_prng]! This will probably
+    /// lead to a stack overflow, as [CoapRng] would recursively call into itself to generate random
+    /// bytes.
+    /// This function will try to catch attempts to do so, but cannot reliably check for all
+    /// possible cases (e.g., if the [CoapRng] is wrapped in another custom type).
+    ///
+    /// # Errors
+    ///
+    /// May return [RngError::GlobalMutexPoisonError] if the underlying mutex protecting the RNG is
+    /// poisoned, i.e. a thread panicked while holding the lock (which should only happen if the
+    /// previously set RNG panicked).
+    ///
+    /// Will return [RngError::CoapRngAsCustomRng] if the [TryRngCore] implementation provided to
+    /// this function is a known reference to a [CoapRng] instance (which would cause infinite
+    /// recursion).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rand_core::{CryptoRng, RngCore};
+    /// use libcoap_rs::error::RngError;
+    /// use libcoap_rs::prng::{coap_prng_try_fill, set_coap_prng};
+    ///
+    /// pub struct NullRng {}
+    ///
+    /// // This implicitly also adds an implementation for TryRngCore, which is the type that is
+    /// // actually required by set_coap_rng().
+    /// impl RngCore for NullRng {
+    ///     fn next_u32(&mut self) -> u32 {
+    ///         0
+    ///     }
+    ///
+    ///     fn next_u64(&mut self) -> u64 {
+    ///         0
+    ///     }
+    ///
+    ///     fn fill_bytes(&mut self, dest: &mut [u8]) {
+    ///         dest.fill(0);
+    ///     }
+    /// }
+    ///
+    /// // Obviously, this is just for demonstration purposes and should not actually be done.
+    /// impl CryptoRng for NullRng {}
+    ///
+    /// set_coap_prng(NullRng{})?;
+    /// let mut token = [1u8; 8];
+    /// coap_prng_try_fill(&mut token)?;
+    ///
+    /// assert_eq!(&token, &[0u8; 8]);
+    ///
+    ///
+    /// # Result::<(), RngError>::Ok(())
+    /// ```
+    pub fn set_coap_prng<RNG: TryRngCore + CryptoRng + Send + Sync + 'static>(rng: RNG) -> Result<(), RngError> {
+        // Check that we aren't adding CoapRng to libcoap (which would cause infinite
+        // recursion/stack overflows).
+        const RECURSIVE_RNG_TYPES: &[TypeId] = &[
+            TypeId::of::<CoapRng>(),
+            TypeId::of::<UnwrapErr<CoapRng>>(),
+            TypeId::of::<UnwrapMut<CoapRng>>(),
+        ];
+        if RECURSIVE_RNG_TYPES.contains(&TypeId::of::<RNG>()) {
+            return Err(RngError::CoapRngAsCustomRng);
+        }
+        ensure_coap_started();
+        let mut guard = COAP_RNG_FN_MUTEX.lock()?;
+        *guard = Some(Box::new(rng));
+        // SAFETY: Pointer is valid and pointed-to function does what libcoap expects.
+        unsafe {
+            coap_set_prng(Some(prng_callback));
+        }
+        drop(guard);
+        Ok(())
+    }
+
+    /// Trait that provides the same functionality as [TryRngCore], but with a fixed error type
+    /// containing no detailed error information.
+    ///
+    /// Used in the type definition for the RNG function container provided to libcoap
+    /// [COAP_RNG_FN_MUTEX], since we can't use [TryRngCore] directly without making the
+    /// type dyn-incompatible.
+    trait ErrorErasingTryRngCore {
+        /// Does the same as [TryRngCore], but converts all errors to [RngError::Unknown].
+        fn try_fill_bytes_erase_error(&mut self, dest: &mut [u8]) -> Result<(), RngError>;
+    }
+
+    impl<T: TryRngCore<Error = E>, E> ErrorErasingTryRngCore for T {
+        fn try_fill_bytes_erase_error(&mut self, dest: &mut [u8]) -> Result<(), RngError> {
+            <T as TryRngCore>::try_fill_bytes(self, dest).map_err(|_e| RngError::Unknown)
+        }
+    }
+
+    /// Callback provided to libcoap for generating random numbers.
+    ///
+    /// # Safety
+    ///
+    /// This function is intended as a [libcoap_sys::coap_rand_func_t], therefore `out` should be valid
+    /// and point to the start of an area of memory that can be filled with `len` bytes.
+    unsafe extern "C" fn prng_callback(out: *mut c_void, len: usize) -> c_int {
+        let out_slice = std::slice::from_raw_parts_mut(out as *mut u8, len);
+        match COAP_RNG_FN_MUTEX.lock() {
+            Ok(mut rng_fn) => rng_fn
+                .as_mut()
+                .expect("rng_callback has been set, but no RNG was set")
+                .try_fill_bytes_erase_error(out_slice)
+                .map_or(0, |_| 1),
+            Err(_e) => 0,
+        }
     }
 }


### PR DESCRIPTION
## Description

`rand` was updated to fix a soundness issue when it is used together with a custom logger.

This bump has caused some API changes, which is why we also had to make some changes to the libcoap-rs-API.
Namely, we use the TryRngCore trait instead of the RngCore trait for both RNGs provided to libcoap and the libcoap-provided RNG, and added some extra checks for common cases of recursively feeding libcoap's RNG as a custom RNG to itself (which would cause infinite recursion).

## How to Test

-

## Related Issues

For maintainers: Refer to the dependabot alert in the Security and Quality Dashboard.

## Checklist

- [x] I have read, understood, and acknowledged the [NOTICE](https://github.com/namib-project/libcoap-rs/blob/main/NOTICE.md) file and the [Contribution Guide](https://github.com/namib-project/libcoap-rs/blob/main/CONTRIBUTING.md)
- [x] I affirm that I have the right to submit the changes made by this pull
      request under the BSD-2-Clause license as indicated in the NOTICE file.
- [x] This PR is either a) free of any LLM-generated code~~, or b) I have
      disclosed all uses of LLM-generated code in this pull request and
      indicated the models that were used.~~
